### PR TITLE
Local path encoding fix

### DIFF
--- a/provider/src/main/java/com/commonsware/cwac/provider/LocalPathStrategy.java
+++ b/provider/src/main/java/com/commonsware/cwac/provider/LocalPathStrategy.java
@@ -184,7 +184,7 @@ public class LocalPathStrategy implements StreamStrategy {
       if (fpath.startsWith(rpath)) {
         b
           .appendPath(name)
-          .appendPath(fpath.substring(rpath.length() + 1));
+          .appendEncodedPath(fpath.substring(rpath.length() + 1));
 
         return(true);
       }


### PR DESCRIPTION
If I feed this input into StreamProvider.getUriForFile():
"/data/user/0/com.myapp/cache/writeable/profile123.tmp"

it returns this:
"content://com.myapp.fileprovider/3242862b-c6c0-45eb-a514-17e3587bc006/cache/writeable%2Fprofile123.tmp"

Notice that the trailing slash after "writeable" has been replaced with "%2F" because it's been encoded.